### PR TITLE
New private method syntax guidelines

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -15,7 +15,8 @@ Much of this was taken from https://github.com/bbatsov/ruby-style-guide and http
 * [Naming](#naming)
 * [Comments](#comments)
 * [Comment Annotations](#comment-annotations)
-* [Classes](#classes--modules)
+* [Classes & Modules](#classes--modules)
+* [Private & Protected Methods](#private--protected-methods)
 * [Exceptions](#exceptions)
 * [Collections](#collections)
 * [Strings](#strings)
@@ -939,16 +940,12 @@ at all.
       def some_method
       end
 
-      # protected and private methods are grouped near the end
-
-
-      def some_protected_method
+      # private methods are grouped near the end
+      private def some_private_method
       end
-      protected :some_protected_method
 
-      def some_private_method
+      private def another_private_method
       end
-      private :some_private_method
     end
     ```
 
@@ -1061,48 +1058,6 @@ in inheritance.
     Parent.print_class_var # => will print "child"
     ```
 
-* Assign proper visibility levels to methods (`private`, `protected`)
-in accordance with their intended usage. Don't go off leaving
-everything `public` (which is the default).
-
-* Pass the method name to `public`, `protected`, and `private` methods one line below the visibility controlled method
-
-    ```ruby
-    #bad
-    class SomeClass
-      def public_method
-        # ...
-      end
-
-      private
-
-      def private_method
-        # ...
-      end
-
-      def another_private_method
-        # ...
-      end
-    end
-
-    #good
-    class SomeClass
-      def public_method
-        # ...
-      end
-
-      def private_method
-        # ...
-      end
-      private :private_method
-
-      def another_private_method
-        # ...
-      end
-      private :private_method
-    end
-    ```
-
 * Avoid class << self except when necessary, e.g. single accessors and aliased attributes.
 
     ```ruby
@@ -1130,6 +1085,99 @@ everything `public` (which is the default).
 
       def self.second_method_etc
         # body omitted
+      end
+    end
+    ```
+
+## Private & Protected Methods
+
+* Avoid using `protected` whenever possible.
+
+* Assign proper visibility levels to methods (`public` or `private`)
+in accordance with their intended usage. Don't go off leaving
+everything `public` (which is the default).
+
+* **For applications/gems with Ruby >= 2.1**, use `private def method_name`.
+
+  ```ruby
+    # good
+    class SomeClass
+      def public_method
+        # ...
+      end
+
+      private def private_method
+        # ...
+      end
+
+      private def another_private_method
+        # ...
+      end
+    end
+  ```
+
+* **For applications with Ruby < 2.1 and gems still supporting Ruby < 2.1**, use
+  `private :method_name` _or_ `private`, depending on the existing convention in place.
+
+* Using `private :method_name`, pass the method name to public, or private one line
+    below the visibility controlled method.
+
+    ```ruby
+    # ok
+    class SomeClass
+      def public_method
+        # ...
+      end
+
+      def private_method
+        # ...
+      end
+      private :private_method
+
+      def another_private_method
+        # ...
+      end
+      private :private_method
+    end
+    ```
+
+* For `private` blocks, indent the `private` methods as much as the method
+    definitions they apply to. Leave one blank line above the visibility modifier
+    and one blank line below in order to emphasize that it applies to all methods
+    below it.  
+
+    ```ruby
+    # bad - private methods are indented too far
+    class SomeClass
+      def public_method
+        # ...
+      end
+
+      private
+
+        def private_method
+          # ...
+        end
+
+        def another_private_method
+          # ...
+        end
+    end
+
+    # ok
+    class SomeClass
+      def public_method
+        # ...
+      end
+
+      private
+
+      def private_method
+        # ...
+      end
+
+      def another_private_method
+        # ...
       end
     end
     ```


### PR DESCRIPTION
**Updated:** After much discussion (about coding style? Imagine that), either convention for Ruby < 2.1 is acceptable; Ruby 2.1+ will use the `private def method_name` syntax allowed by Ruby 2.1 with `def` returning a symbol.

https://bugs.ruby-lang.org/issues/7998

-----

After using the `private :method` with its definition for some time in internal Sport Ngin code and using the [more standard] singular `private` declaration in _everything else in the Ruby world_, I argue that the former does more harm than good and is a very awkward non-conventional-looking Ruby.

The current convention...
* Is not a convention. I have yet to see a single project which _consistently_ uses `private :method`. In fact, if you work with any of the major open source Ruby projects you will find that this proposed change is essentially how Ruby is idiomatically written. No, really - if anyone knows of any major projects that use the current style, ping me, I'd like to see it.
* Adds an insane amount of clutter to files. If you have a larger class, it's not actually easier to read with private declarations all over - it's quite a bit harder.
* Allows you to mix public/private/projected methods, allowing for more mistakes if you forget the private declaration (happens all the time, I've seen it).
* I literally took the code in this PR from the very [styleguide that this one is based on.](https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#indent-public-private-protected)

Misc responses to arguments for the current style that I've heard:

> But then declaration of `private` is always found with the method; when you have a super long class, you can't get lost in what is and isn't private!

* If you have a super long class where you literally get lost in method definitions, that's code smell. You've got much bigger problems, my friend.
* If that super long class already exists and you can't really refactor it (you just have to deal with it), it's still going to look more awful and cluttered using the current style.
* If you are adding a method to the bottom of a class that you intend to be public, I'm happy with that - when Ruby yells at you that you've called a private method and need to think harder about where you're placing it, that's a good thing.

> Where the method is located in a file doesn't have any bearing on it's privacy

* Who says that's a bad thing? If you used _standard convention_, you'd be knocking out two styleguide points at once, as you'd be [essentially] forced to put private methods at the bottom of the file where they belong.

Summing up, let's write Ruby how Ruby is usually written (it's done that way for a reason).~~