### PR TITLE
Stop checking block length in specs

### DIFF
--- a/global_rubocop.yml
+++ b/global_rubocop.yml
@@ -31,6 +31,10 @@ Layout/MultilineOperationIndentation:
 Style/AccessModifierDeclarations:
   EnforcedStyle: inline
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Rails/UnknownEnv:
   Environments:
     - development


### PR DESCRIPTION
This is happening, and it's insane when you think about it: https://github.com/sportngin/user_service/pull/969/files#r263444603

specs rely on large blocks, it's literally how they work. We aren't going to break specs into smaller files because that's insane. Just skip this check on specs.

QA: Just pass it...