### PR TITLE
Exclude specs from line length

### DIFF
--- a/global_rubocop.yml
+++ b/global_rubocop.yml
@@ -3,6 +3,8 @@ Metrics/ClassLength:
 
 Metrics/LineLength:
   Max: 120
+  Exclude:
+    - 'spec/**/*'
 
 Metrics/MethodLength:
   Max: 25


### PR DESCRIPTION
Do not do line length checks in specs, matchers are often over length and it's a pain.

QA: Add the label