### PR TITLE
COMP-7507 Remove mixpanel activation

### DIFF
--- a/_includes/JB/analytics
+++ b/_includes/JB/analytics
@@ -5,8 +5,6 @@
   {% include JB/analytics-providers/google %}
 {% when "getclicky" %}
   {% include JB/analytics-providers/getclicky %}
-{% when "mixpanel" %}
-  {% include JB/analytics-providers/mixpanel %}
 {% when "custom" %}
   {% include custom/analytics %}
 {% endcase %}


### PR DESCRIPTION
What
----------------------
This PR removes conditionally activating Mixpanel. 

Why
----------------------
Mixpanel is generating a cookie header blob so large that an overflow occurs when purchasing memberships. This is a critical bug. 

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.
* [Jira issue COMP-7507](https://sportngin.atlassian.net/browse/COMP-7507)

QA Plan
-------
- [x] N/A