### PR TITLE
Update rubocop yml for linelength

### DIFF
--- a/global_rubocop.yml
+++ b/global_rubocop.yml
@@ -1,44 +1,29 @@
-Metrics/ClassLength:
-  Enabled: false
-
 Layout/LineLength:
   Max: 120
   Exclude:
     - 'spec/**/*'
 
-Metrics/MethodLength:
-  Max: 25
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Style/Documentation:
-  Enabled: false
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
 
 Metrics/AbcSize:
   Max: 50
 
-Style/Alias:
-  EnforcedStyle: prefer_alias_method
-
-Metrics/ModuleLength:
-  Max: 200
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
-
-Style/AccessModifierDeclarations:
-  EnforcedStyle: inline
-
-Style/FormatStringToken:
-  EnforcedStyle: template
-
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/MethodLength:
+  Max: 25
+
+Metrics/ModuleLength:
+  Max: 200
 
 Rails/UnknownEnv:
   Environments:
@@ -46,3 +31,18 @@ Rails/UnknownEnv:
     - test
     - production
     - staging
+
+Style/AccessModifierDeclarations:
+  EnforcedStyle: inline
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+Style/Documentation:
+  Enabled: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/global_rubocop.yml
+++ b/global_rubocop.yml
@@ -1,7 +1,7 @@
 Metrics/ClassLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   Exclude:
     - 'spec/**/*'


### PR DESCRIPTION
RuboCop updated their heirarchy and moved linelength to Layout from Metrics.  This will stop your IDE from yelling at you every time RuboCop tries to format a file.

QA:
- [x] Check the box...add the label