### PR TITLE
Use Consistent Hash Indentation Cop

### DIFF
--- a/global_rubocop.yml
+++ b/global_rubocop.yml
@@ -6,6 +6,9 @@ Layout/LineLength:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
 Metrics/AbcSize:
   Max: 50
 


### PR DESCRIPTION
Updating Cop to use Consistent Hash indentation Cop.

QA:
- [ ] After deploy, run this command in Ngin: `rubocop app/services/hq_permission_service.rb`
- [ ] There should be no warnings for `Layout/MultilineOperationIndentation`